### PR TITLE
51 move xxx nornir nuts context.nornir filter up to base class

### DIFF
--- a/nuts/base_tests/napalm_bgp_neighbors.py
+++ b/nuts/base_tests/napalm_bgp_neighbors.py
@@ -2,12 +2,10 @@
 from typing import Dict, Callable, List, Any
 
 import pytest
-from nornir.core.filter import F
 from nornir.core.task import MultiResult, Result
 from nornir_napalm.plugins.tasks import napalm_get
 
 from nuts.context import NornirNutsContext
-from nuts.helpers.filters import filter_hosts
 from nuts.helpers.result import AbstractHostResultExtractor, NutsResult
 
 
@@ -36,9 +34,6 @@ class BgpNeighborsContext(NornirNutsContext):
 
     def nuts_arguments(self) -> Dict[str, List[str]]:
         return {"getters": ["bgp_neighbors"]}
-
-    def nornir_filter(self) -> F:
-        return filter_hosts(self.nuts_parameters["test_data"])
 
     def nuts_extractor(self) -> BgpNeighborsExtractor:
         return BgpNeighborsExtractor(self)

--- a/nuts/base_tests/napalm_get_users.py
+++ b/nuts/base_tests/napalm_get_users.py
@@ -2,12 +2,10 @@
 from typing import Dict, Callable, List, Any
 
 import pytest
-from nornir.core.filter import F
 from nornir.core.task import MultiResult, Result
 from nornir_napalm.plugins.tasks import napalm_get
 
 from nuts.context import NornirNutsContext
-from nuts.helpers.filters import filter_hosts
 from nuts.helpers.result import AbstractHostResultExtractor, NutsResult
 
 
@@ -22,9 +20,6 @@ class UsersContext(NornirNutsContext):
 
     def nuts_arguments(self) -> Dict[str, List[str]]:
         return {"getters": ["users"]}
-
-    def nornir_filter(self) -> F:
-        return filter_hosts(self.nuts_parameters["test_data"])
 
     def nuts_extractor(self) -> UsersExtractor:
         return UsersExtractor(self)

--- a/nuts/base_tests/napalm_interfaces.py
+++ b/nuts/base_tests/napalm_interfaces.py
@@ -2,12 +2,10 @@
 from typing import Dict, Callable, List, Any
 
 import pytest
-from nornir.core.filter import F
 from nornir.core.task import MultiResult, Result
 from nornir_napalm.plugins.tasks import napalm_get
 
 from nuts.context import NornirNutsContext
-from nuts.helpers.filters import filter_hosts
 from nuts.helpers.result import AbstractHostResultExtractor, NutsResult
 
 
@@ -22,9 +20,6 @@ class InterfacesContext(NornirNutsContext):
 
     def nuts_arguments(self) -> Dict[str, List[str]]:
         return {"getters": ["interfaces"]}
-
-    def nornir_filter(self) -> F:
-        return filter_hosts(self.nuts_parameters["test_data"])
 
     def nuts_extractor(self) -> InterfacesExtractor:
         return InterfacesExtractor(self)

--- a/nuts/base_tests/napalm_lldp_neighbors.py
+++ b/nuts/base_tests/napalm_lldp_neighbors.py
@@ -2,13 +2,11 @@
 from typing import Dict, Callable, List, Any
 
 import pytest
-from nornir.core.filter import F
 from nornir.core.task import MultiResult, Result
 from nornir_napalm.plugins.tasks import napalm_get
 
 from nuts.context import NornirNutsContext
 from nuts.helpers.converters import InterfaceNameConverter
-from nuts.helpers.filters import filter_hosts
 from nuts.helpers.result import AbstractHostResultExtractor, NutsResult
 
 
@@ -42,9 +40,6 @@ class LldpNeighborsContext(NornirNutsContext):
 
     def nuts_arguments(self) -> Dict[str, List[str]]:
         return {"getters": ["lldp_neighbors_detail"]}
-
-    def nornir_filter(self) -> F:
-        return filter_hosts(self.nuts_parameters["test_data"])
 
     def nuts_extractor(self) -> LldpNeighborsExtractor:
         return LldpNeighborsExtractor(self)

--- a/nuts/base_tests/napalm_network_instances.py
+++ b/nuts/base_tests/napalm_network_instances.py
@@ -2,11 +2,9 @@
 from typing import Dict, List, Callable, Any
 
 import pytest
-from nornir.core.filter import F
 from nornir.core.task import MultiResult, Result
 from nornir_napalm.plugins.tasks import napalm_get
 
-from nuts.helpers.filters import filter_hosts
 from nuts.helpers.result import AbstractHostResultExtractor, NutsResult
 from nuts.context import NornirNutsContext
 
@@ -34,9 +32,6 @@ class NetworkInstancesContext(NornirNutsContext):
 
     def nuts_arguments(self) -> Dict[str, List[str]]:
         return {"getters": ["network_instances"]}
-
-    def nornir_filter(self) -> F:
-        return filter_hosts(self.nuts_parameters["test_data"])
 
     def nuts_extractor(self) -> NetworkInstancesExtractor:
         return NetworkInstancesExtractor(self)

--- a/nuts/base_tests/napalm_ping.py
+++ b/nuts/base_tests/napalm_ping.py
@@ -4,12 +4,10 @@ from typing import Dict, Callable, Any, List
 
 import pytest
 from nornir.core import Task
-from nornir.core.filter import F
 from nornir.core.task import Result
 from nornir_napalm.plugins.tasks import napalm_ping
 
 from nuts.context import NornirNutsContext
-from nuts.helpers.filters import filter_hosts
 from nuts.helpers.result import (
     NutsResult,
     AbstractHostDestResultExtractor,
@@ -109,9 +107,6 @@ class PingContext(NornirNutsContext):
             result = task.run(task=napalm_ping, dest=destination, **kwargs)
             result[0].destination = destination  # type: ignore[attr-defined]
         return Result(host=task.host, result="All pings executed")
-
-    def nornir_filter(self) -> F:
-        return filter_hosts(self.nuts_parameters["test_data"])
 
     def nuts_extractor(self) -> PingExtractor:
         return PingExtractor(self)

--- a/nuts/base_tests/netmiko_cdp_neighbors.py
+++ b/nuts/base_tests/netmiko_cdp_neighbors.py
@@ -2,11 +2,9 @@
 from typing import Callable, Dict, Any
 
 import pytest
-from nornir.core.filter import F
 from nornir.core.task import MultiResult, Result
 from nornir_netmiko import netmiko_send_command
 
-from nuts.helpers.filters import filter_hosts
 from nuts.helpers.result import AbstractHostResultExtractor, NutsResult
 from nuts.context import NornirNutsContext
 
@@ -23,9 +21,6 @@ class CdpNeighborsContext(NornirNutsContext):
 
     def nuts_arguments(self) -> Dict[str, Any]:
         return {"command_string": "show cdp neighbors detail", "use_textfsm": True}
-
-    def nornir_filter(self) -> F:
-        return filter_hosts(self.nuts_parameters["test_data"])
 
     def nuts_extractor(self) -> CdpNeighborsExtractor:
         return CdpNeighborsExtractor(self)

--- a/nuts/base_tests/netmiko_iperf.py
+++ b/nuts/base_tests/netmiko_iperf.py
@@ -4,12 +4,11 @@ import json
 from typing import Dict, Callable, Any
 import shlex
 
-from nornir.core.filter import F
 from nornir.core.task import Task, Result
+from nornir.core.filter import F
 from nornir_netmiko import netmiko_send_command
 
 from nuts.context import NornirNutsContext
-from nuts.helpers.filters import filter_hosts
 from nuts.helpers.errors import Error
 from nuts.helpers.result import NutsResult, AbstractHostDestResultExtractor
 
@@ -69,9 +68,6 @@ class IperfContext(NornirNutsContext):
             )
             result[0].destination = destination  # type: ignore[attr-defined]
         return Result(host=task.host, result=f"iperf executed for {task.host}")
-
-    def nornir_filter(self) -> F:
-        return filter_hosts(self.nuts_parameters["test_data"])
 
     def setup(self) -> None:
         """

--- a/nuts/base_tests/netmiko_ospf_neighbors.py
+++ b/nuts/base_tests/netmiko_ospf_neighbors.py
@@ -2,12 +2,10 @@
 from typing import Callable, Dict, Any
 
 import pytest
-from nornir.core.filter import F
 from nornir.core.task import MultiResult, Result
 from nornir_netmiko import netmiko_send_command
 
 from nuts.context import NornirNutsContext
-from nuts.helpers.filters import filter_hosts
 from nuts.helpers.result import AbstractHostResultExtractor, NutsResult
 
 
@@ -23,9 +21,6 @@ class OspfNeighborsContext(NornirNutsContext):
 
     def nuts_arguments(self) -> Dict[str, Any]:
         return {"command_string": "show ip ospf neighbor", "use_textfsm": True}
-
-    def nornir_filter(self) -> F:
-        return filter_hosts(self.nuts_parameters["test_data"])
 
     def nuts_extractor(self) -> OspfNeighborsExtractor:
         return OspfNeighborsExtractor(self)

--- a/nuts/context.py
+++ b/nuts/context.py
@@ -10,6 +10,7 @@ from nornir.core.filter import F
 
 from nuts.helpers.errors import NutsSetupError
 from nuts.helpers.result import AbstractResultExtractor
+from nuts.helpers.filters import filter_hosts
 
 
 class NutsContext:
@@ -109,11 +110,11 @@ class NornirNutsContext(NutsContext):
         """
         raise NotImplementedError
 
-    def nornir_filter(self) -> Optional[F]:
+    def nornir_filter(self) -> F:
         """
         :return: A nornir filter that is applied to the nornir instance
         """
-        return None
+        return filter_hosts(self.nuts_parameters["test_data"])
 
     def general_result(self) -> AggregatedResult:
         """

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -252,9 +252,6 @@ class TestNornirNutsContextIntegration:
         def nuts_task(self):
             return lambda task: task.host.name
 
-        def nornir_filter(self) -> F:
-            return filter_hosts(self.nuts_parameters["test_data"])
-
 
     CONTEXT = CustomNornirNutsContext
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -120,7 +120,9 @@ class TestNornirNutsContextIntegration:
                         ---
                         - test_module: basic_task
                           test_class: TestBasicTask
-                          test_data: ['test1', 'test2']
+                          test_data:
+                            - host: R1
+                            - host: R2
                         """,
         }
         pytester.makefile(YAML_EXTENSION, **arguments)
@@ -151,7 +153,9 @@ class TestNornirNutsContextIntegration:
                 ---
                 - test_module: basic_task
                   test_class: TestBasicTask
-                  test_data: ['test1', 'test2']
+                  test_data:
+                    - host: R1
+                    - host: R2
                 """
         }
         pytester.makefile(YAML_EXTENSION, **arguments)
@@ -222,7 +226,8 @@ class TestNornirNutsContextIntegration:
                 ---
                 - test_module: basic_task
                   test_class: TestOtherConfigFile
-                  test_data: ['test1']
+                  test_data:
+                    - host: R1
                 """
         }
         pytester.makefile(YAML_EXTENSION, **arguments)


### PR DESCRIPTION
Move the method `nornir_filter()` of `NornirNutsContext`-Subclasses up to the `NornirNutsContext` class, since it is the same everywhere. If a distinct implementation for one test class would be needed, this would still be possible.